### PR TITLE
Design: 검색 결과 페이지 - 마크업, css

### DIFF
--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,10 +1,26 @@
+'use client';
+
 import UnderBar from '@/components/common/Footer';
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 
 /* ai 검색창 페이지 */
 export default function SearchPage() {
+  const goBack = useRouter();
+
   return (
     <>
+      <header>
+        <button
+          type="button"
+          onClick={() => goBack.back()}
+          aria-label="뒤로 가기"
+          className="font-pretendard flex flex-row gap-3.5 mt-4.5 ml-5.5 items-center"
+        >
+          <Image src="/icons/arrow-left.svg" alt="" width={8} height={16} />
+          <span className="leading-none mb-0.5">AI 검색</span>
+        </button>
+      </header>
       <main className="font-pretendard min-h-screen flex flex-col items-center text-center">
         <Image
           src="/icons/aisearch-sparkle.svg"
@@ -14,10 +30,10 @@ export default function SearchPage() {
           className="mt-42.5"
         />
 
-        <p className="text-2xl mt-3.75">
+        <span className="text-2xl mt-3.75">
           AI 검색으로 나의 포포에게
           <br /> 맞는 상품을 추천해드려요.
-        </p>
+        </span>
         <div className="relative w-85.75 mt-12.75">
           <Image
             src="/icons/aisearch-generation.svg"
@@ -37,9 +53,9 @@ export default function SearchPage() {
         </div>
 
         <div className="text-br-input-disabled-line text-[13px] mt-4.5 flex flex-col gap-2.25">
-          <p>&quot;시니어 강아지가 먹을 간식 뭐야?&quot;</p>
-          <p>&quot;활동량 적은 고양이 장난감 추천해 줘!&quot;</p>
-          <p>&quot;관절 사료 추천해 줘!&quot;</p>
+          <span>&quot;시니어 강아지가 먹을 간식 뭐야?&quot;</span>
+          <span>&quot;활동량 적은 고양이 장난감 추천해 줘!&quot;</span>
+          <span>&quot;관절 사료 추천해 줘!&quot;</span>
         </div>
       </main>
       <UnderBar />

--- a/app/search/result/page.tsx
+++ b/app/search/result/page.tsx
@@ -1,1 +1,60 @@
 /* 검색 결과 페이지 */
+'use client';
+
+import UnderBar from '@/components/common/Footer';
+import ProductList from '@/components/common/ProductList';
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+
+export default function SearchResultPage() {
+  const goBack = useRouter();
+  return (
+    <>
+      <div className="font-pretendard pb-15">
+        <header>
+          <button
+            type="button"
+            onClick={() => goBack.back()}
+            aria-label="뒤로 가기"
+            className="font-pretendard flex flex-row gap-3.5 mt-4.5 ml-5.5 items-center"
+          >
+            <Image src="/icons/arrow-left.svg" alt="" width={8} height={16} />
+            <span className="leading-none mb-0.5">AI 검색 결과</span>
+          </button>
+        </header>
+        <section>
+          <div className="flex flex-row items-center gap-1.5 mt-8 ml-4.75">
+            <Image
+              src="/icons/aisearch-sparkle.svg"
+              alt=""
+              width={25}
+              height={25}
+            />
+            <p className="text-br-button-disabled-text leading-6 text-[13px]">
+              <span className="text-br-primary-500">
+                &quot;말랑한 간식&quot;
+              </span>{' '}
+              분석 결과 <br /> 총 5개의 맞춤 상품을 찾았습니다.
+            </p>
+          </div>
+        </section>
+        <main className="px-4 mt-7.25">
+          <p className="text-[18px]">AI 추천 상품</p>
+          <ProductList />
+          <ProductList />
+          <ProductList />
+          <ProductList />
+          <ProductList />
+          <button
+            type="button"
+            className="w-full h-12 rounded-xl bg-br-button-more-bg text-br-button-more-text mt-5 mb-13"
+          >
+            일반 검색 결과 더보기
+          </button>
+        </main>
+
+        <UnderBar />
+      </div>
+    </>
+  );
+}

--- a/components/common/Footer.tsx
+++ b/components/common/Footer.tsx
@@ -7,11 +7,17 @@ import { usePathname } from 'next/navigation';
 //푸터
 export default function UnderBar() {
   const pathname = usePathname();
-  const isActive = (href: string) => pathname === href; // pathname과 href가 같으면 true, 아니면 false를 반환
+  const isActive = (href: string) => {
+    // 홈인 (/products)은 정확히 /products일 때만 활성
+    if (href === '/products') return pathname === '/products';
+
+    // 나머지는 하위 경로까지 활성
+    return pathname === href || pathname.startsWith(`${href}/`);
+  };
 
   return (
     <>
-      <div className="fixed bottom-0 left-0 right-0 font-pretendard flex justify-between items-center w-full h-15 shadow-[0_-6px_12px_-8px_rgba(0,0,0,0.12)] px-[36.86px]">
+      <div className="bg-white fixed bottom-0 left-0 right-0 font-pretendard flex justify-between items-center w-full h-15 shadow-[0_-6px_12px_-8px_rgba(0,0,0,0.12)] px-[36.86px]">
         <Link href="/products" className="flex flex-col items-center gap-0.75">
           <Image
             src={

--- a/components/common/ProductList.tsx
+++ b/components/common/ProductList.tsx
@@ -1,0 +1,50 @@
+import Image from 'next/image';
+import Link from 'next/link';
+
+export default function ProductList() {
+  return (
+    <>
+      <Link href={`/products/`} className="flex flex-row w-full mt-4.25 gap-4">
+        {/* 썸네일 */}
+        <div className="relative w-21 h-21 overflow-hidden rounded-xl shrink-0">
+          <Image
+            src="https://res.cloudinary.com/ddedslqvv/image/upload/v1768981576/febc15-final01-ecad/qBJjByQxs.png"
+            alt="강아지 실 장난감"
+            fill
+            className="object-cover"
+          />
+        </div>
+
+        {/* 텍스트 영역 */}
+        <div className="font-pretendard flex-1 min-w-0 flex flex-col justify-between">
+          <div>
+            <p className="text-[14px] line-clamp-2">
+              강아지 실 장난감 판매합니다!! 터그 놀이용이고 새 상품이에요~!
+            </p>
+            <p className="text-[16px] font-bold">5,000원</p>
+          </div>
+          <div className="flex flex-row items-center gap-1">
+            <div className="flex flex-row items-center gap-0.5">
+              <Image
+                src="/icons/visile.svg"
+                alt="조회 수"
+                width={12}
+                height={12}
+              />
+              <span className="text-[12px]">103</span>
+            </div>
+            <div className="flex flex-row items-center gap-0.5">
+              <Image
+                src="/icons/heart-line.svg"
+                alt="조회 수"
+                width={12}
+                height={12}
+              />
+              <span className="text-[12px]">2</span>
+            </div>
+          </div>
+        </div>
+      </Link>
+    </>
+  );
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,15 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'res.cloudinary.com',
+      },
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## PR 요약
- 검색 결과 페이지 마크업, css 작업
- 하단바 수정

## 변경 내용
- search/result에 검색 결과 페이지 마크업 및 css 작업 완료
- next.config.ts 파일 수정
- 하단바 라우팅 주소 수정
  - 페이지간 이동이 있을 때 하단바의 아이콘(색깔이 채워진)이 유지되지 않음 -> 상품 상세 페이지를 제외하곤 유지될 수 있도록 변경


## 마주했던 문제 상황
- 몽고DB의 img path를 그대로 src 주소에 넣었을 때 이미지가 렌더링 되지 않는 오류가 발생
  - src에 Cloudinary URL을 넣었는데, Next가 이 도메인은 허용 목록에 없어서 next/image로는 못 불러옴. 따라서 next.config.ts 파일에 아래와 같은 코드 추가
```
images: {
    remotePatterns: [
      {
        protocol: 'https',
        hostname: 'res.cloudinary.com',
      },
    ],
  },
```

## 메인 이슈
- #21 