### PR TITLE
Modify: 스플래시 화면 추가

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,6 @@
+import SplashScreen from '@/components/common/SplashScreen';
 import './globals.css';
+import { Suspense } from 'react';
 
 export default function RootLayout({
   children,
@@ -7,7 +9,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko">
-      <body>{children}</body>
+      <body>
+        <Suspense fallback={<SplashScreen />}>{children}</Suspense>
+      </body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import UnderBar from '@/components/common/Footer';
-import AuthPage from './auth/page'; /* 확인용 - 삭제 */
+import ProductPage from '@/app/products/page';
+
 /* 
 임시 확인용 URL - 추후 삭제 예정
 http://localhost:3000/login
@@ -8,13 +9,7 @@ http://localhost:3000/login
 export default function Home() {
   return (
     <>
-      <AuthPage /> {/* 확인용 - 삭제 */}
-      <h1 className="text-red-500 text-4xl">final-project-sample v05</h1>
-      <h1 className="text-br-error">final-project-sample v05</h1>
-      <h2>client-id: {process.env.NEXT_PUBLIC_CLIENT_ID}</h2>
-      <div className="bg-br-primary-500 text-br-button-disabled-text font-pretendard">
-        커스텀 스타일
-      </div>
+      <ProductPage />
       <UnderBar />
     </>
   );

--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -2,7 +2,10 @@ import UnderBar from '@/components/common/Footer';
 import Image from 'next/image';
 import Link from 'next/link';
 
-export default function ProductPage() {
+export default async function ProductPage() {
+  // 스플래시 화면이 나오도록 2.5초 지연 걸어둠
+  await new Promise(resolve => setTimeout(resolve, 1000 * 2.5));
+
   const categories = ['전체', '사료', '간식', '용품', '건강', '의류'];
   // 기능 구현때 번경 예정
   const subCategories = ['건식', '습식/화식', '건조', '기타'];

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from 'react';
 
 import UnderBar from '@/components/common/Footer';
 import Image from 'next/image';
-import { useRouter } from 'next/navigation';
+import Header from '@/components/common/Header';
 
 const hints = [
   '"시니어 강아지가 먹을 간식 뭐야?"',
@@ -14,8 +14,6 @@ const hints = [
 ];
 
 export default function SearchPage() {
-  const router = useRouter();
-
   const [hintIndex, setHintIndex] = useState(0);
 
   useEffect(() => {
@@ -30,18 +28,7 @@ export default function SearchPage() {
       {/* 화면 전체 래퍼 */}
       <div className="font-pretendard min-h-screen pb-15">
         {/* 헤더 */}
-        <header className="px-4 pt-4.5">
-          <button
-            type="button"
-            onClick={() => router.back()}
-            aria-label="뒤로 가기"
-            className="flex items-center gap-3.5"
-          >
-            <Image src="/icons/arrow-left.svg" alt="" width={8} height={16} />
-            <span className="leading-none">AI 검색</span>
-          </button>
-        </header>
-
+        <Header title="AI 검색" />
         {/* 본문 */}
         <main className="px-4">
           <div className="mx-auto w-full max-w-130 flex flex-col items-center text-center">

--- a/app/search/result/page.tsx
+++ b/app/search/result/page.tsx
@@ -2,26 +2,15 @@
 'use client';
 
 import UnderBar from '@/components/common/Footer';
-import ProductList from '@/components/common/ProductList';
+import Header from '@/components/common/Header';
+import ProductList from '@/components/searchresult/ProductList';
 import Image from 'next/image';
-import { useRouter } from 'next/navigation';
 
 export default function SearchResultPage() {
-  const goBack = useRouter();
   return (
     <>
       <div className="font-pretendard pb-15">
-        <header>
-          <button
-            type="button"
-            onClick={() => goBack.back()}
-            aria-label="뒤로 가기"
-            className="font-pretendard flex flex-row gap-3.5 mt-4.5 ml-5.5 items-center"
-          >
-            <Image src="/icons/arrow-left.svg" alt="" width={8} height={16} />
-            <span className="leading-none mb-0.5">AI 검색 결과</span>
-          </button>
-        </header>
+        <Header title="AI 검색 결과" />
         <section>
           <div className="flex flex-row items-center gap-1.5 mt-8 ml-4.75">
             <Image

--- a/components/common/SplashScreen.tsx
+++ b/components/common/SplashScreen.tsx
@@ -1,0 +1,48 @@
+import Image from 'next/image';
+
+export default function SplashScreen() {
+  return (
+    <>
+      <section className="min-h-screen w-screen font-pretendard bg-br-primary-500">
+        <div className="min-h-screen flex flex-col items-center justify-center">
+          <span className="text-br-chip-disabled-bg">
+            for four, 반려동물을 위한 중고마켓
+          </span>
+          <Image
+            src="/icons/logo-white.svg"
+            alt="FOFO"
+            width={195}
+            height={50}
+          />
+          <div className="relative mt-4.25 flex flex-col">
+            <div>
+              <Image
+                src="/icons/footprint.svg"
+                alt="발자국"
+                width={26}
+                height={28}
+              />
+            </div>
+            <div className="-ml-6.5 mt-1.5">
+              <Image
+                src="/icons/footprint.svg"
+                alt="발자국"
+                width={26}
+                height={28}
+                className="rotate-12"
+              />
+            </div>
+            <div className="mt-3.75">
+              <Image
+                src="/icons/footprint.svg"
+                alt="발자국"
+                width={26}
+                height={28}
+              />
+            </div>
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/components/searchresult/ProductList.tsx
+++ b/components/searchresult/ProductList.tsx
@@ -26,21 +26,25 @@ export default function ProductList() {
           <div className="flex flex-row items-center gap-1">
             <div className="flex flex-row items-center gap-0.5">
               <Image
-                src="/icons/visile.svg"
+                src="/icons/visile-gray.svg"
                 alt="조회 수"
                 width={12}
                 height={12}
               />
-              <span className="text-[12px]">103</span>
+              <span className="text-[12px] text-br-button-disabled-text">
+                103
+              </span>
             </div>
             <div className="flex flex-row items-center gap-0.5">
               <Image
-                src="/icons/heart-line.svg"
+                src="/icons/heart-line-gray.svg"
                 alt="조회 수"
                 width={12}
                 height={12}
               />
-              <span className="text-[12px]">2</span>
+              <span className="text-[12px] text-br-button-disabled-text">
+                2
+              </span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## PR 유형

- 새로운 기능 추가


## 변경 내용, **기능 추가:**
- 접속 시 스플래시 화면이 렌더링 될 수 있도록 Suspense를 이용하여 구현.
- 2.5초간 스플래시 화면이 보여진 후 홈 화면인 상품 리스트 페이지가 렌더링 됨.

## 마주했던 문제 상황
- Suspense를 이용해서 로딩 화면을 구현한 거라 상품 페이지에서 새로고침 시 스플래시 화면이 계속 렌더링 됨.


## 관련 이슈, 메인 이슈
- #53 
