### PR TITLE
Feat: 검색 결과 페이지 - 검색 결과 추출 기능 구현 1차 완료.

### DIFF
--- a/actions/ai-search/search.ts
+++ b/actions/ai-search/search.ts
@@ -1,1 +1,100 @@
+'use server';
+
+import cosineSimilarity from '@/lib/utils/similarity';
+import {
+  EmbeddingProducts,
+  ProductList,
+  ProductSearchList,
+} from '@/types/product';
+import OpenAI from 'openai';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL;
+const CLIENT_ID = process.env.NEXT_PUBLIC_CLIENT_ID;
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+
+const openai = new OpenAI({
+  apiKey: OPENAI_API_KEY,
+});
+
+// 텍스트를 임베딩하는 함수
+async function getEmbedding(text: string): Promise<number[]> {
+  const response = await openai.embeddings.create({
+    model: 'text-embedding-3-small',
+    input: text,
+  });
+
+  return response.data[0].embedding;
+}
+
 // 검색어 임베딩 데이터와 상품 설명 임베딩 데이터 비교하는 작업
+export async function SimilarityCompare(
+  formData: FormData
+): Promise<ProductSearchList[]> {
+  try {
+    // 1. 폼 데이터인 검색어 추출
+    const searchQuery = formData.get('query') as string;
+
+    if (!searchQuery) {
+      throw new Error('검색어가 없습니다');
+    }
+
+    console.log(`검색어: ${searchQuery}`);
+
+    // 2. 검색어 임베딩
+    const queryEmbedding = await getEmbedding(searchQuery);
+    console.log(`검색어 임베딩 완료`);
+
+    // 3. 모든 상품 목록 조회
+    const listRes = await fetch(`${API_URL}/products`, {
+      headers: {
+        'Content-Type': 'application/json',
+        'Client-Id': CLIENT_ID!,
+      },
+    });
+
+    if (!listRes.ok) {
+      throw new Error('상품 목록 조회 실패');
+    }
+
+    const listData = await listRes.json();
+    const products: EmbeddingProducts = listData.item;
+
+    console.log(`총 ${products.length}개 상품 조회`);
+
+    // 4. 각 상품의 임베딩과 유사도 계산
+
+    // 4-1. 코사인 유사도 값을 저장하는 배열 생성
+    const similarityArr = [];
+
+    for (let i = 0; i < products.length; i++) {
+      // 임베딩이 없는 상품은 스킵
+      if (!products[i].extra.embeddings?.length) {
+        continue;
+      }
+
+      // 4-2. 유사도 계산
+      const similarity = cosineSimilarity(
+        queryEmbedding,
+        products[i].extra.embeddings as number[]
+      );
+
+      // 4-3. 상품 _id와 유사도를 같이 저장
+      similarityArr.push({ _id: products[i]._id, similarity: similarity });
+    }
+
+    // 4-4. 유사도 높은 5개 추출해서 높은 순으로 정렬
+    const highSimilarity = similarityArr
+      .sort((a, b) => b.similarity - a.similarity)
+      .slice(0, 5);
+
+    // 5개가 저장된 highSimilarity의 _id와 상품 목록에 있는 상품들의 _id 비교
+    const productsList: ProductList[] = listData.item;
+    const searchResult: ProductSearchList[] = highSimilarity.map(item => {
+      return productsList.find(p => p._id === item._id)!;
+    });
+    return searchResult;
+  } catch (error) {
+    console.error('유사도 비교 실패:', error);
+    return [];
+  }
+}

--- a/app/search/result/page.tsx
+++ b/app/search/result/page.tsx
@@ -4,10 +4,67 @@
 import UnderBar from '@/components/common/Footer';
 import Header from '@/components/common/Header';
 import ProductList from '@/components/search/ProductList';
+import { useSearchStore } from '@/store/searchStore';
+import { ProductSearchList } from '@/types/product';
 
 import Image from 'next/image';
+import { useSearchParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL;
+const CLIENT_ID = process.env.NEXT_PUBLIC_CLIENT_ID;
 
 export default function SearchResultPage() {
+  const [proudcts, setProducts] = useState<ProductSearchList[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // url의 id 정보가 담긴 쿼리 파리미터 가져오기
+  const searchParams = useSearchParams();
+
+  // 전역으로 저장한 useSearchStore의 query 값을 가져옴
+  const queryText = useSearchStore(s => s.query);
+
+  // 상품 상세 정보 불러오는 api 호출 함수
+  async function searchResult(id: string): Promise<ProductSearchList> {
+    const res = await fetch(`${API_URL}/products/${id}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        'Client-Id': CLIENT_ID!,
+      },
+    });
+    const data = await res.json();
+    return data.item;
+  }
+
+  // 상품 정보 가져오기
+  useEffect(() => {
+    const idsString = searchParams.get('ids');
+    const idArray = idsString?.split(',') || [];
+
+    const loadProducts = async () => {
+      try {
+        // result: Promise 5개가 배열로 있음(아직 상품 정보 아님 -> 아직 pending 상태!)
+        // await Promise.all()로 모든 Promise 완료 대기 후 실제 상품 정보 추출
+        const result = idArray.map(id => searchResult(id));
+        // productList가 실제 상품 정보 5개를 담고 있는 배열
+        const productList = await Promise.all(result);
+
+        setProducts(productList);
+      } catch (error) {
+        console.error('상품 조회 실패', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    if (idArray.length > 0) {
+      loadProducts();
+    }
+  }, [searchParams]);
+
+  if (isLoading) {
+    return <div>검색 결과 찾는 중...</div>;
+  }
   return (
     <>
       <div className="font-pretendard pb-15">
@@ -22,7 +79,7 @@ export default function SearchResultPage() {
             />
             <p className="text-br-button-disabled-text leading-6 text-[13px]">
               <span className="text-br-primary-500">
-                &quot;말랑한 간식&quot;
+                &quot;{queryText}&quot;
               </span>{' '}
               분석 결과 <br /> 총 5개의 맞춤 상품을 찾았습니다.
             </p>
@@ -30,11 +87,9 @@ export default function SearchResultPage() {
         </section>
         <main className="px-4 mt-7.25">
           <p className="text-[18px]">AI 추천 상품</p>
-          <ProductList />
-          <ProductList />
-          <ProductList />
-          <ProductList />
-          <ProductList />
+          {proudcts.map(product => {
+            return <ProductList key={product._id} product={product} />;
+          })}
           <button
             type="button"
             className="w-full h-12 rounded-xl bg-br-button-more-bg text-br-button-more-text mt-5 mb-13"

--- a/components/search/ProductList.tsx
+++ b/components/search/ProductList.tsx
@@ -1,15 +1,23 @@
+import { ProductSearchList } from '@/types/product';
 import Image from 'next/image';
 import Link from 'next/link';
 
-export default function ProductList() {
+interface ProdcutListProps {
+  product: ProductSearchList;
+}
+
+export default function ProductList({ product }: ProdcutListProps) {
   return (
     <>
-      <Link href={`/products/1`} className="flex flex-row w-full mt-4.25 gap-4">
+      <Link
+        href={`/products/${product._id}`}
+        className="flex flex-row w-full mt-4.25 gap-4"
+      >
         {/* 썸네일 */}
         <div className="relative w-21 h-21 overflow-hidden rounded-xl shrink-0">
           <Image
-            src="https://res.cloudinary.com/ddedslqvv/image/upload/v1768981576/febc15-final01-ecad/qBJjByQxs.png"
-            alt="강아지 실 장난감"
+            src={product.mainImages[0].path}
+            alt={product.mainImages[0].name}
             fill
             className="object-cover"
           />
@@ -18,10 +26,10 @@ export default function ProductList() {
         {/* 텍스트 영역 */}
         <div className="font-pretendard flex-1 min-w-0 flex flex-col justify-between">
           <div>
-            <p className="text-[14px] line-clamp-2">
-              강아지 실 장난감 판매합니다!! 터그 놀이용이고 새 상품이에요~!
+            <p className="text-[14px] line-clamp-2">{product.name}</p>
+            <p className="text-[16px] font-bold">
+              {product.price.toLocaleString('ko-KR')}원
             </p>
-            <p className="text-[16px] font-bold">5,000원</p>
           </div>
           <div className="flex flex-row items-center gap-1">
             <div className="flex flex-row items-center gap-0.5">
@@ -32,7 +40,7 @@ export default function ProductList() {
                 height={12}
               />
               <span className="text-[12px] text-br-button-disabled-text">
-                103
+                {product.views}
               </span>
             </div>
             <div className="flex flex-row items-center gap-0.5">
@@ -43,7 +51,7 @@ export default function ProductList() {
                 height={12}
               />
               <span className="text-[12px] text-br-button-disabled-text">
-                2
+                {product.bookmarks}
               </span>
             </div>
           </div>

--- a/components/search/SearchForm.tsx
+++ b/components/search/SearchForm.tsx
@@ -1,10 +1,42 @@
+// 검색 폼
 'use client';
 
+import { SimilarityCompare } from '@/actions/ai-search/search';
+import { useSearchStore } from '@/store/searchStore';
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
 export default function SearchForm() {
   const [searchValue, setSearchValue] = useState('');
+  const router = useRouter();
+
+  // useSearchStore 훅에서 setQuery 함수만 꺼내서 setQuery 변수에 할당
+  // zustand에서 store 객체의 프로퍼티를 꺼낼 때 화살표 함수로 넘겨줌
+  const setQuery = useSearchStore(s => s.setQuery);
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault(); // 페이지 새로고침 방지
+
+    if (!searchValue.trim()) {
+      alert('검색어를 입력해주세요');
+      return;
+    }
+
+    // 폼 데이터 생성
+    const formData = new FormData();
+    formData.append('query', searchValue);
+
+    // 서버 액션 호출(results는 유사도 높은 5개가 담긴 배열을 반환 받은 값)
+    const results = await SimilarityCompare(formData);
+    const idList = results.map(item => item._id).join(',');
+
+    // setQuery에 검색창 입력 값 넘겨줌.
+    setQuery(searchValue);
+
+    // 페이지 이동
+    router.push(`/search/result?ids=${idList}`);
+  };
 
   return (
     <>
@@ -17,7 +49,7 @@ export default function SearchForm() {
           className="absolute left-4 top-1/2 -translate-y-1/2"
         />
 
-        <form>
+        <form onSubmit={handleSubmit}>
           {/* 서버로 검색어 전달 */}
           <input type="hidden" name="keyword" value={searchValue} />
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "swiper": "^12.1.0",
-        "zustand": "^5.0.10"
+        "zustand": "^5.0.11"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -6595,9 +6595,9 @@
       }
     },
     "node_modules/zustand": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.10.tgz",
-      "integrity": "sha512-U1AiltS1O9hSy3rul+Ub82ut2fqIAefiSuwECWt6jlMVUGejvf+5omLcRBSzqbRagSM3hQZbtzdeRc6QVScXTg==",
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.11.tgz",
+      "integrity": "sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==",
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "swiper": "^12.1.0",
-    "zustand": "^5.0.10"
+    "zustand": "^5.0.11"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/store/searchStore.ts
+++ b/store/searchStore.ts
@@ -1,0 +1,19 @@
+// 검색어를 저장하는 전역 변수 생성
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+type SearchState = {
+  query: string;
+  setQuery: (q: string) => void;
+};
+
+// 전역에서 쓸 수 있는 useSearchState 훅 생성
+export const useSearchStore = create<SearchState>()(
+  persist(
+    set => ({
+      query: '', // query의 초기 값
+      setQuery: q => set({ query: q }), // query의 상태 변경을 해주는 set 함수
+    }),
+    { name: 'search-store' }
+  )
+);

--- a/types/product.ts
+++ b/types/product.ts
@@ -30,13 +30,14 @@ export interface Product {
   rating: number;
 }
 
+// 임베딩 된 상품 목록 조회
+export type EmbeddingProducts = Array<Pick<Product, '_id' | 'extra'>>;
+
 // 검색 결과용 Product
 export type ProductSearchList = Pick<
   Product,
-  '_id' | 'name' | 'price' | 'mainImages' | 'bookmarks'
-> & {
-  similarity: number; // 유사도
-};
+  '_id' | 'name' | 'price' | 'mainImages' | 'bookmarks' | 'views'
+>;
 
 // 검색 결과 응답 타입 -> 얘만 따로
 export interface ProductSearchListRes {


### PR DESCRIPTION
## PR 유형

- 새로운 기능 추가

## 변경 내용, **기능 추가:**
- 입력된 검색어를 임베딩 하여 임베딩 처리된 상품 설명과 유사도 비교해서 유사도가 높은 5개의 상품을 추출하여 검색 결과 페이지에 렌더링
  - 두 개를 비교해서 유사도 계산하는 로직을  actions/search.ts에 서버 액션 함수를 정의함.
  - 5개 상품의 id를 검색 결과 페이지에 url의 파라미터로 넘겨서 꺼낼 수 있도록 함.
- store/searchStore.ts에 검색어를 zustand를 사용해서 전역 상태로 설정하여 검색 결과 페이지에서 불러올 수 있도록 함.

## 관련 이슈, 메인 이슈
- #100 
